### PR TITLE
Pass original renderChallenge to user defined renderChallenge

### DIFF
--- a/pages/challenge.js
+++ b/pages/challenge.js
@@ -24,7 +24,7 @@ export async function displayChallenge(challengeId, renderChallenge) {
 
     // Call user func
     if (CTFd._functions.challenge.renderChallenge) {
-      CTFd._functions.challenge.renderChallenge(internal);
+      CTFd._functions.challenge.renderChallenge(internal, renderChallenge);
     } else if (renderChallenge) {
       renderChallenge(internal);
     }


### PR DESCRIPTION
* Pass original `renderChallenge` to user defined `CTFd._functions.challenge.renderChallenge`
* This properly allows for customization during the render challenge phase where previously the user defined renderChallenge could not call back into the original function meaning you would need to copy the entire behavior and it would need to be theme specific