### PR TITLE
Mark 0.0.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ctfdio/ctfd-js",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "Javascript library for CTFd interface interactivity",
   "main": "main.js",
   "repository": {


### PR DESCRIPTION
* `CTFd.pages.challenge.loadUnlock` now has a second argument that specifies the target's type (defaults to `hints`)
* Added `CTFd.pages.challenge.displayHintUnlock`
* Added `CTFd.pages.challenge.displaySolutionUnlock`
* Deprecated `CTFd.pages.challenge.displayUnlock`
* Fixed issues with `CTFd.pages.challenge.displaySolution` and `CTFd.pages.challenge.displayHint`